### PR TITLE
Feature button tts guide

### DIFF
--- a/app/lib/description/app_guide_page.dart
+++ b/app/lib/description/app_guide_page.dart
@@ -42,6 +42,12 @@ WalkGuide는 시각장애인의 안전한 보행을 돕기 위해 설계된 앱�
   }
 
   @override
+  void dispose() {
+    _flutterTts.stop(); // 페이지를 벗어날 때 음성 중지
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('앱 사용법')),

--- a/app/lib/description/app_guide_page.dart
+++ b/app/lib/description/app_guide_page.dart
@@ -1,7 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:walk_guide/voice_guide_service.dart';
 
-class AppGuidePage extends StatelessWidget {
+class AppGuidePage extends StatefulWidget {
   const AppGuidePage({super.key});
+
+  @override
+  State<AppGuidePage> createState() => _AppGuidePageState();
+}
+
+class _AppGuidePageState extends State<AppGuidePage> {
+  final FlutterTts _flutterTts = FlutterTts();
+
+  @override
+  void initState() {
+    super.initState();
+    _speakIntroIfEnabled();
+  }
+
+  Future<void> _speakIntroIfEnabled() async {
+    final enabled = await isNavigationVoiceEnabled();
+    if (!enabled) return;
+
+    final String fullText = '''
+앱 사용법 페이지입니다.
+WalkGuide 앱에 오신 것을 환영합니다.
+WalkGuide는 시각장애인의 안전한 보행을 돕기 위해 설계된 앱입니다.
+이 앱을 통해 실시간 안내와 보행 분석 기능을 제공합니다.
+
+첫째, 실시간 안내 기능입니다.
+음성 안내 제공, 장애물 경고, AI 피드백을 제공합니다.
+
+둘째, 보행 데이터 분석입니다.
+걸음 수, 속도, 정지 구간을 시각화하며
+데이터 백업 및 복원 기능도 지원합니다.
+''';
+
+    await _flutterTts.setLanguage("ko-KR");
+    await _flutterTts.setSpeechRate(0.5);
+    await _flutterTts.speak(fullText);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -20,11 +58,13 @@ class AppGuidePage extends StatelessWidget {
               style: TextStyle(fontSize: 16),
             ),
             SizedBox(height: 24),
-            Text('1. 실시간 안내 기능', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 17)),
+            Text('1. 실시간 안내 기능',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 17)),
             SizedBox(height: 6),
             Text('- 음성 안내 제공\n- 장애물 경고\n- AI 피드백'),
             SizedBox(height: 24),
-            Text('2. 보행 데이터 분석', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 17)),
+            Text('2. 보행 데이터 분석',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 17)),
             SizedBox(height: 6),
             Text('- 걸음 수, 속도, 정지 구간 시각화\n- 데이터 백업 및 복원'),
           ],

--- a/app/lib/description/company_info_page.dart
+++ b/app/lib/description/company_info_page.dart
@@ -1,7 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:walk_guide/voice_guide_service.dart'; // 음성 안내 설정 확인용
 
-class CompanyInfoPage extends StatelessWidget {
+class CompanyInfoPage extends StatefulWidget {
   const CompanyInfoPage({super.key});
+
+  @override
+  State<CompanyInfoPage> createState() => _CompanyInfoPageState();
+}
+
+class _CompanyInfoPageState extends State<CompanyInfoPage> {
+  final FlutterTts _flutterTts = FlutterTts();
+
+  @override
+  void initState() {
+    super.initState();
+    _speakIntroText(); // 페이지 진입 시 안내
+  }
+
+  Future<void> _speakIntroText() async {
+    final enabled = await isNavigationVoiceEnabled();
+    if (enabled) {
+      const text = '앱 제작자 소개 페이지입니다. 충북대학교. 팀명 SCORE. 김병우, 권오섭, 전수영, 김선영';
+      await _flutterTts.setLanguage("ko-KR");
+      await _flutterTts.setSpeechRate(0.5);
+      await _flutterTts.speak(text);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -10,14 +35,31 @@ class CompanyInfoPage extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
         children: const [
-          Text('충북대학교', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          Text('충북대학교',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           SizedBox(height: 12),
           Text('팀명: SCORE', style: TextStyle(fontSize: 16)),
           Divider(height: 32),
-          ListTile(leading: Icon(Icons.person), title: Text('김병우'), subtitle: Text('~~~~~')),
-          ListTile(leading: Icon(Icons.person), title: Text('권오섭'), subtitle: Text('~~~~~')),
-          ListTile(leading: Icon(Icons.person), title: Text('전수영'), subtitle: Text('~~~~~')),
-          ListTile(leading: Icon(Icons.person), title: Text('김선영'), subtitle: Text('~~~~~')),
+          ListTile(
+            leading: Icon(Icons.person),
+            title: Text('김병우'),
+            subtitle: Text('~~~~~'),
+          ),
+          ListTile(
+            leading: Icon(Icons.person),
+            title: Text('권오섭'),
+            subtitle: Text('~~~~~'),
+          ),
+          ListTile(
+            leading: Icon(Icons.person),
+            title: Text('전수영'),
+            subtitle: Text('~~~~~'),
+          ),
+          ListTile(
+            leading: Icon(Icons.person),
+            title: Text('김선영'),
+            subtitle: Text('~~~~~'),
+          ),
         ],
       ),
     );

--- a/app/lib/description/company_info_page.dart
+++ b/app/lib/description/company_info_page.dart
@@ -29,14 +29,22 @@ class _CompanyInfoPageState extends State<CompanyInfoPage> {
   }
 
   @override
+  void dispose() {
+    _flutterTts.stop(); // 페이지 벗어나면 음성 출력 중지
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('앱 제작자 소개')),
       body: ListView(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
         children: const [
-          Text('충북대학교',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          Text(
+            '충북대학교',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
           SizedBox(height: 12),
           Text('팀명: SCORE', style: TextStyle(fontSize: 16)),
           Divider(height: 32),

--- a/app/lib/description/description_page.dart
+++ b/app/lib/description/description_page.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tts/flutter_tts.dart';
+import 'package:walk_guide/voice_guide_service.dart'; // 추가
 import 'account_info_page.dart';
 import 'privacy_policy_page.dart';
 import 'app_guide_page.dart';
@@ -47,10 +48,13 @@ class _DescriptionPageState extends State<DescriptionPage> {
     }
   }
 
-  Future<void> _speak(String text) async {
-    await _flutterTts.setLanguage("ko-KR");
-    await _flutterTts.setSpeechRate(0.5);
-    await _flutterTts.speak(text);
+  Future<void> _speakIfEnabled(String text) async {
+    final enabled = await isNavigationVoiceEnabled(); // 설정 불러오기
+    if (enabled) {
+      await _flutterTts.setLanguage("ko-KR");
+      await _flutterTts.setSpeechRate(0.5);
+      await _flutterTts.speak(text);
+    }
   }
 
   @override
@@ -72,8 +76,8 @@ class _DescriptionPageState extends State<DescriptionPage> {
           children: [
             const SizedBox(height: 16),
             GestureDetector(
-              onTap: () {
-                _speak("계정 정보를 확인하는 페이지로 이동합니다.");
+              onTap: () async {
+                await _speakIfEnabled("계정 정보를 확인하는 페이지로 이동합니다."); // 조건부 음성 안내
                 Navigator.push(
                   context,
                   MaterialPageRoute(builder: (_) => const AccountInfoPage()),
@@ -115,8 +119,9 @@ class _DescriptionPageState extends State<DescriptionPage> {
             ...items.map((item) => Padding(
                   padding: const EdgeInsets.symmetric(vertical: 18),
                   child: GestureDetector(
-                    onTap: () {
-                      _speak("${item.title} 페이지로 이동합니다.");
+                    onTap: () async {
+                      await _speakIfEnabled(
+                          "${item.title} 페이지로 이동합니다."); // 조건부 음성 안내
                       Navigator.push(
                         context,
                         MaterialPageRoute(builder: (_) => item.page),

--- a/app/lib/description/description_page.dart
+++ b/app/lib/description/description_page.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
 import 'account_info_page.dart';
 import 'privacy_policy_page.dart';
 import 'app_guide_page.dart';
@@ -17,6 +18,7 @@ class DescriptionPage extends StatefulWidget {
 
 class _DescriptionPageState extends State<DescriptionPage> {
   String? nickname;
+  final FlutterTts _flutterTts = FlutterTts();
 
   final List<_DescriptionItem> items = [
     _DescriptionItem('보행 데이터 관리', PrivacyPolicyPage()),
@@ -35,11 +37,20 @@ class _DescriptionPageState extends State<DescriptionPage> {
   Future<void> fetchNickname() async {
     final user = FirebaseAuth.instance.currentUser;
     if (user != null) {
-      final doc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+      final doc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .get();
       setState(() {
         nickname = doc.data()?['nickname'] ?? '사용자';
       });
     }
+  }
+
+  Future<void> _speak(String text) async {
+    await _flutterTts.setLanguage("ko-KR");
+    await _flutterTts.setSpeechRate(0.5);
+    await _flutterTts.speak(text);
   }
 
   @override
@@ -62,6 +73,7 @@ class _DescriptionPageState extends State<DescriptionPage> {
             const SizedBox(height: 16),
             GestureDetector(
               onTap: () {
+                _speak("계정 정보를 확인하는 페이지로 이동합니다.");
                 Navigator.push(
                   context,
                   MaterialPageRoute(builder: (_) => const AccountInfoPage()),
@@ -73,7 +85,7 @@ class _DescriptionPageState extends State<DescriptionPage> {
                     width: 80,
                     height: 80,
                     decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20),  
+                      borderRadius: BorderRadius.circular(20),
                       image: const DecorationImage(
                         image: AssetImage('assets/images/profile.jpg'),
                         fit: BoxFit.cover,
@@ -85,35 +97,37 @@ class _DescriptionPageState extends State<DescriptionPage> {
                     TextSpan(
                       children: [
                         TextSpan(
-                            text: nickname ?? '...',
-                            style: const TextStyle(fontSize: 25, fontWeight: FontWeight.bold),
-                          ),
+                          text: nickname ?? '...',
+                          style: const TextStyle(
+                              fontSize: 25, fontWeight: FontWeight.bold),
+                        ),
                         const TextSpan(
                           text: '님',
-                            style: TextStyle(fontSize: 25),
-                            ),
-                        ],
-                      ),
+                          style: TextStyle(fontSize: 25),
+                        ),
+                      ],
                     ),
+                  ),
                 ],
               ),
             ),
             const SizedBox(height: 20),
             ...items.map((item) => Padding(
-              padding: const EdgeInsets.symmetric(vertical: 18),
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => item.page),
-                  );
-                },
-                child: Text(
-                  item.title,
-                  style: const TextStyle(fontSize: 22),
-                ),
-              ),
-            )),
+                  padding: const EdgeInsets.symmetric(vertical: 18),
+                  child: GestureDetector(
+                    onTap: () {
+                      _speak("${item.title} 페이지로 이동합니다.");
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (_) => item.page),
+                      );
+                    },
+                    child: Text(
+                      item.title,
+                      style: const TextStyle(fontSize: 22),
+                    ),
+                  ),
+                )),
           ],
         ),
       ),

--- a/app/lib/description/faq_page.dart
+++ b/app/lib/description/faq_page.dart
@@ -1,29 +1,87 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:walk_guide/voice_guide_service.dart';
 
-class FAQPage extends StatelessWidget {
+class FAQPage extends StatefulWidget {
   const FAQPage({super.key});
+
+  @override
+  State<FAQPage> createState() => _FAQPageState();
+}
+
+class _FAQPageState extends State<FAQPage> {
+  final FlutterTts _flutterTts = FlutterTts();
+
+  Future<void> _speakIfEnabled(String text) async {
+    final enabled = await isNavigationVoiceEnabled();
+    if (enabled) {
+      await _flutterTts.setLanguage("ko-KR");
+      await _flutterTts.setSpeechRate(0.5);
+      await _flutterTts.speak(text);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('자주 묻는 질문')),
       body: ListView(
-        children: const [
+        children: [
           ExpansionTile(
-            title: Text('앱이 아무 말도 하지 않아요.'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('음성 안내 설정을 확인하세요.'))],
+            title: const Text('앱이 아무 말도 하지 않아요.'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("앱이 아무 말도 하지 않아요. 음성 안내 설정을 확인하세요.");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('음성 안내 설정을 확인하세요.'),
+              ),
+            ],
           ),
           ExpansionTile(
-            title: Text('데이터가 초기화됐어요.'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('로그인 계정을 확인해주세요.'))],
+            title: const Text('데이터가 초기화됐어요.'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("데이터가 초기화됐어요. 로그인 계정을 확인해주세요.");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('로그인 계정을 확인해주세요.'),
+              ),
+            ],
           ),
           ExpansionTile(
-            title: Text('앱이 갑자기 종료돼요.'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('앱을 최신 버전으로 업데이트해주세요.'))],
+            title: const Text('앱이 갑자기 종료돼요.'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("앱이 갑자기 종료돼요. 앱을 최신 버전으로 업데이트해주세요.");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('앱을 최신 버전으로 업데이트해주세요.'),
+              ),
+            ],
           ),
           ExpansionTile(
-            title: Text('피드백을 보내고 싶어요.'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('문의하기를 이용해주세요.'))],
+            title: const Text('피드백을 보내고 싶어요.'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("피드백을 보내고 싶어요. 문의하기를 이용해주세요.");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('문의하기를 이용해주세요.'),
+              ),
+            ],
           ),
         ],
       ),

--- a/app/lib/description/faq_page.dart
+++ b/app/lib/description/faq_page.dart
@@ -22,6 +22,12 @@ class _FAQPageState extends State<FAQPage> {
   }
 
   @override
+  void dispose() {
+    _flutterTts.stop(); // 페이지를 벗어날 때 음성 중지
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('자주 묻는 질문')),

--- a/app/lib/description/privacy_policy_page.dart
+++ b/app/lib/description/privacy_policy_page.dart
@@ -38,6 +38,12 @@ JSON 파일로 백업 및 복원이 가능합니다.
   }
 
   @override
+  void dispose() {
+    _flutterTts.stop(); // 페이지 나갈 때 음성 안내 중지
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/app/lib/description/privacy_policy_page.dart
+++ b/app/lib/description/privacy_policy_page.dart
@@ -1,7 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:walk_guide/voice_guide_service.dart';
 
-class PrivacyPolicyPage extends StatelessWidget {
+class PrivacyPolicyPage extends StatefulWidget {
   const PrivacyPolicyPage({super.key});
+
+  @override
+  State<PrivacyPolicyPage> createState() => _PrivacyPolicyPageState();
+}
+
+class _PrivacyPolicyPageState extends State<PrivacyPolicyPage> {
+  final FlutterTts _flutterTts = FlutterTts();
+
+  @override
+  void initState() {
+    super.initState();
+    _readContentIfEnabled();
+  }
+
+  Future<void> _readContentIfEnabled() async {
+    final enabled = await isNavigationVoiceEnabled();
+    if (!enabled) return;
+
+    const String fullText = '''
+보행 데이터 관리 페이지입니다.
+
+첫째, 데이터 저장 위치.
+모든 보행 데이터는 로컬 Hive에 안전하게 저장됩니다.
+
+둘째, 백업 및 복원.
+JSON 파일로 백업 및 복원이 가능합니다.
+''';
+
+    await _flutterTts.setLanguage("ko-KR");
+    await _flutterTts.setSpeechRate(0.5);
+    await _flutterTts.speak(fullText);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/description/technology_page.dart
+++ b/app/lib/description/technology_page.dart
@@ -1,29 +1,88 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:walk_guide/voice_guide_service.dart';
 
-class TechnologyPage extends StatelessWidget {
+class TechnologyPage extends StatefulWidget {
   const TechnologyPage({super.key});
+
+  @override
+  State<TechnologyPage> createState() => _TechnologyPageState();
+}
+
+class _TechnologyPageState extends State<TechnologyPage> {
+  final FlutterTts _flutterTts = FlutterTts();
+
+  Future<void> _speakIfEnabled(String title, String detail) async {
+    final enabled = await isNavigationVoiceEnabled();
+    if (enabled) {
+      final String fullText = "$title. $detail";
+      await _flutterTts.setLanguage("ko-KR");
+      await _flutterTts.setSpeechRate(0.5);
+      await _flutterTts.speak(fullText);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('사용된 기술 및 기능')),
       body: ListView(
-        children: const [
+        children: [
           ExpansionTile(
-            title: Text('센서 사용'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('sensors_plus 사용'))],
+            title: const Text('센서 사용'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("센서 사용", "sensors_plus 사용");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('sensors_plus 사용'),
+              ),
+            ],
           ),
           ExpansionTile(
-            title: Text('AI 기반 안내'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('보행 속도 학습'))],
+            title: const Text('AI 기반 안내'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("AI 기반 안내", "보행 속도 학습");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('보행 속도 학습'),
+              ),
+            ],
           ),
           ExpansionTile(
-            title: Text('음성 안내'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('Flutter TTS 사용'))],
+            title: const Text('음성 안내'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("음성 안내", "Flutter TTS 사용");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('Flutter TTS 사용'),
+              ),
+            ],
           ),
           ExpansionTile(
-            title: Text('로컬 저장소 Hive'),
-            children: [Padding(padding: EdgeInsets.all(8), child: Text('데이터 저장 및 복원'))],
+            title: const Text('로컬 저장소 Hive'),
+            onExpansionChanged: (expanded) {
+              if (expanded) {
+                _speakIfEnabled("로컬 저장소 Hive", "데이터 저장 및 복원");
+              }
+            },
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('데이터 저장 및 복원'),
+              ),
+            ],
           ),
         ],
       ),

--- a/app/lib/description/technology_page.dart
+++ b/app/lib/description/technology_page.dart
@@ -23,6 +23,12 @@ class _TechnologyPageState extends State<TechnologyPage> {
   }
 
   @override
+  void dispose() {
+    _flutterTts.stop(); // 페이지 나갈 때 음성 안내 중지
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('사용된 기술 및 기능')),

--- a/app/lib/main_page.dart
+++ b/app/lib/main_page.dart
@@ -34,8 +34,9 @@ class _MainScreenState extends State<MainScreen> {
     _loadNicknameAndGreet();
     _getCurrentLocation();
 
-    _walkStartFocusNode.addListener(() {
-      if (_walkStartFocusNode.hasFocus) {
+    _walkStartFocusNode.addListener(() async {
+      final enabled = await isNavigationVoiceEnabled();
+      if (_walkStartFocusNode.hasFocus && enabled) {
         _flutterTts.speak("보행을 시작하려면 이 버튼을 누르세요.");
       }
     });
@@ -212,6 +213,8 @@ class _MainScreenState extends State<MainScreen> {
             ),
           ],
           onTap: (index) async {
+            final navigationVoiceEnabled = await isNavigationVoiceEnabled();
+
             if (index == 0) {
               if (widget.cameras.isEmpty) {
                 ScaffoldMessenger.of(context).showSnackBar(
@@ -220,7 +223,9 @@ class _MainScreenState extends State<MainScreen> {
                 return;
               }
 
-              await _flutterTts.speak("보행을 시작합니다.");
+              if (navigationVoiceEnabled) {
+                await _flutterTts.speak("보행을 시작합니다.");
+              }
 
               Navigator.push(
                 context,
@@ -234,7 +239,10 @@ class _MainScreenState extends State<MainScreen> {
                 ),
               );
             } else if (index == 1) {
-              await _flutterTts.speak("분석 페이지로 이동합니다.");
+              if (navigationVoiceEnabled) {
+                await _flutterTts.speak("분석 페이지로 이동합니다.");
+              }
+
               Navigator.push(
                 context,
                 MaterialPageRoute(
@@ -242,7 +250,10 @@ class _MainScreenState extends State<MainScreen> {
                 ),
               );
             } else if (index == 2) {
-              await _flutterTts.speak("설정 페이지로 이동합니다.");
+              if (navigationVoiceEnabled) {
+                await _flutterTts.speak("설정 페이지로 이동합니다.");
+              }
+
               Navigator.push(
                 context,
                 MaterialPageRoute(

--- a/app/lib/settings_page.dart
+++ b/app/lib/settings_page.dart
@@ -10,6 +10,7 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   bool _voiceEnabled = true;
+  bool _navigationVoiceEnabled = true; //  페이지 이동 음성 안내 여부
 
   @override
   void initState() {
@@ -19,8 +20,10 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future<void> _loadVoiceSetting() async {
     final enabled = await isVoiceGuideEnabled();
+    final navEnabled = await isNavigationVoiceEnabled(); // 따로 저장된 값 로드
     setState(() {
       _voiceEnabled = enabled;
+      _navigationVoiceEnabled = navEnabled;
     });
   }
 
@@ -28,6 +31,13 @@ class _SettingsPageState extends State<SettingsPage> {
     await setVoiceGuideEnabled(value);
     setState(() {
       _voiceEnabled = value;
+    });
+  }
+
+  Future<void> _toggleNavigationVoiceSetting(bool value) async {
+    await setNavigationVoiceEnabled(value); // 새로 추가될 저장 함수
+    setState(() {
+      _navigationVoiceEnabled = value;
     });
   }
 
@@ -45,6 +55,12 @@ class _SettingsPageState extends State<SettingsPage> {
             subtitle: const Text('앱 실행 시 음성 환영 메시지 재생'),
             value: _voiceEnabled,
             onChanged: _toggleVoiceSetting,
+          ),
+          SwitchListTile(
+            title: const Text('페이지 이동 음성 안내'),
+            subtitle: const Text('버튼 터치 시 목적지를 음성으로 알려줍니다'),
+            value: _navigationVoiceEnabled,
+            onChanged: _toggleNavigationVoiceSetting,
           ),
         ],
       ),

--- a/app/lib/voice_guide_service.dart
+++ b/app/lib/voice_guide_service.dart
@@ -1,5 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+// ✅ 환영 음성 안내 설정
 Future<void> setVoiceGuideEnabled(bool enabled) async {
   final prefs = await SharedPreferences.getInstance();
   await prefs.setBool('voice_guide_enabled', enabled);
@@ -8,4 +9,15 @@ Future<void> setVoiceGuideEnabled(bool enabled) async {
 Future<bool> isVoiceGuideEnabled() async {
   final prefs = await SharedPreferences.getInstance();
   return prefs.getBool('voice_guide_enabled') ?? true;
+}
+
+// 페이지 이동 음성 안내 설정
+Future<void> setNavigationVoiceEnabled(bool enabled) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setBool('navigation_voice_enabled', enabled);
+}
+
+Future<bool> isNavigationVoiceEnabled() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getBool('navigation_voice_enabled') ?? true;
 }


### PR DESCRIPTION
# 페이지별 음성 안내 기능 추가 및 페이지 이탈 시 음성 중지 기능 구현

##  변경 사항
- 각 소개 페이지(AppGuide, CompanyInfo, PrivacyPolicy, TechnologyPage, FAQPage)에 음성 안내 기능 추가
  - 페이지 진입 시 또는 항목 확장 시 Flutter TTS로 음성 출력
  - 음성 내용은 각 페이지의 안내 또는 설명 내용을 기반으로 작성
- `dispose()`에서 `flutterTts.stop()` 호출하여
  - 페이지를 나가면 음성 안내가 자동으로 중지되도록 처리함

##  수정된 주요 파일
- `app_guide_page.dart`
- `company_info_page.dart`
- `privacy_policy_page.dart`
- `technology_page.dart`
- `faq_page.dart`

##  테스트
- 페이지 진입 시 음성 안내 정상 출력 확인
- 페이지 이탈 후 음성 중단 기능 정상 작동 확인

## 🔗 관련 이슈
- closes #118 #117 
