### PR TITLE
Feature unittest map

### DIFF
--- a/app/coverage_calc.py
+++ b/app/coverage_calc.py
@@ -1,0 +1,43 @@
+import os
+
+target_file = 'lib/map/map_screen.dart'
+lcov_path = 'coverage/lcov.info'
+
+if not os.path.exists(lcov_path):
+    print("❌ lcov.info not found.")
+    exit()
+
+with open(lcov_path, 'r') as file:
+    lines = file.readlines()
+
+current_file = None
+executed_lines = 0
+total_lines = 0
+target_found = False
+
+header = f"{'File':<35} {'Stmts':<6} {'Miss':<6} {'Cover':<6}"
+separator = "-" * len(header)
+print(header)
+print(separator)
+
+for line in lines:
+    if line.startswith('SF:'):
+        current_file = line.strip().split('SF:')[1].replace("\\", "/")
+        executed_lines = 0
+        total_lines = 0
+
+    elif line.startswith('DA:'):
+        total_lines += 1
+        _, count = line.strip().split(',')
+        if int(count) > 0:
+            executed_lines += 1
+
+    elif line.startswith('end_of_record') and current_file:
+        if current_file == target_file.replace("\\", "/"):
+            target_found = True
+            missed = total_lines - executed_lines
+            coverage = (executed_lines / total_lines) * 100 if total_lines > 0 else 0.0
+            print(f"{current_file:<35} {total_lines:<6} {missed:<6} {coverage:>5.1f}%")
+
+if not target_found:
+    print("Target file not found in coverage report.")

--- a/app/lib/main_page.dart
+++ b/app/lib/main_page.dart
@@ -6,13 +6,14 @@ import 'package:walk_guide/description/description_page.dart';
 import 'package:walk_guide/analytics_dashboard_page.dart';
 import 'package:walk_guide/settings_page.dart';
 import 'package:walk_guide/voice_guide_service.dart';
+import 'package:walk_guide/map/map_screen.dart';
 import 'package:camera/camera.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:flutter_map/flutter_map.dart';
 
 class MainScreen extends StatefulWidget {
   final List<CameraDescription> cameras;
@@ -34,7 +35,7 @@ class _MainScreenState extends State<MainScreen> {
   void initState() {
     super.initState();
     print("MainScreen initState 들어옴");
-    _setPortraitOrientation(); // Ensure portrait on init
+    _setPortraitOrientation();
     _loadNicknameAndGreet();
     _getCurrentLocation();
 
@@ -61,7 +62,6 @@ class _MainScreenState extends State<MainScreen> {
       DeviceOrientation.landscapeRight,
     ]);
   }
-
 
   @override
   void dispose() {
@@ -105,18 +105,18 @@ class _MainScreenState extends State<MainScreen> {
       final newLocation = LatLng(position.latitude, position.longitude);
 
       if (mounted) {
-          setState(() {
-            _currentLocation = newLocation;
-          });
-           _mapController.move(newLocation, 16.0);
+        setState(() {
+          _currentLocation = newLocation;
+        });
+        _mapController.move(newLocation, 16.0);
       }
     } catch (e) {
-        print("위치 가져오기 실패: $e");
-        if(mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('현재 위치를 가져오는 데 실패했습니다.'))
-            );
-        }
+      print("위치 가져오기 실패: $e");
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('현재 위치를 가져오는 데 실패했습니다.')),
+        );
+      }
     }
   }
 
@@ -172,54 +172,17 @@ class _MainScreenState extends State<MainScreen> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => const DescriptionPage(),
-                  ),
+                      builder: (context) => const DescriptionPage()),
                 ).then((_) async {
-                   if (mounted) await _flutterTts.stop();
+                  if (mounted) await _flutterTts.stop();
                 });
               },
             ),
           ],
         ),
-        body: FlutterMap(
+        body: MapScreen(
+          currentLocation: _currentLocation,
           mapController: _mapController,
-          options: MapOptions(
-            initialCenter: _currentLocation ?? LatLng(37.5665, 126.9780),
-            initialZoom: 15.0,
-            minZoom: 3.0,
-            maxZoom: 18.0,
-            maxBounds: LatLngBounds(
-              LatLng(-85.0, -180.0),
-              LatLng(85.0, 180.0),
-            ),
-          ),
-          children: [
-            TileLayer(
-              urlTemplate:
-                  "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
-              subdomains: const ['a', 'b', 'c'],
-              userAgentPackageName: 'com.oss.walk_guide',
-              tileProvider: NetworkTileProvider(),
-              tileSize: 256,
-              retinaMode: true,
-              backgroundColor: Colors.white,
-            ),
-            if (_currentLocation != null)
-              MarkerLayer(
-                markers: [
-                  Marker(
-                    point: _currentLocation!,
-                    width: 50,
-                    height: 50,
-                    child: Image.asset(
-                      'assets/images/walkingIcon.png',
-                      width: 50,
-                      height: 50,
-                    ),
-                  ),
-                ],
-              ),
-          ],
         ),
         floatingActionButton: FloatingActionButton(
           backgroundColor: Colors.grey.withOpacity(0.6),
@@ -230,7 +193,7 @@ class _MainScreenState extends State<MainScreen> {
             if (_currentLocation != null) {
               _mapController.move(_currentLocation!, 16.0);
             } else {
-              if(mounted) {
+              if (mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('현재 위치를 가져올 수 없습니다.')),
                 );
@@ -267,11 +230,11 @@ class _MainScreenState extends State<MainScreen> {
 
             if (index == 0) {
               if (widget.cameras.isEmpty) {
-                 if(mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
+                if (mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('사용 가능한 카메라가 없습니다.')),
-                    );
-                 }
+                  );
+                }
                 return;
               }
 
@@ -292,30 +255,28 @@ class _MainScreenState extends State<MainScreen> {
                   ),
                 ),
               ).then((_) {
-                print("Returned from StepCounterPage. Ensuring portrait orientation in MainScreen.");
+                print(
+                    "Returned from StepCounterPage. Ensuring portrait orientation in MainScreen.");
                 _setPortraitOrientation();
               });
             } else if (index == 1) {
               if (navigationVoiceEnabled && mounted) {
                 await _flutterTts.speak("분석 페이지로 이동합니다.");
               }
-              await _setPortraitOrientation(); // Ensure portrait before navigating
+              await _setPortraitOrientation();
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const AnalyticsDashboardPage(),
-                ),
+                    builder: (context) => const AnalyticsDashboardPage()),
               ).then((_) => _setPortraitOrientation());
             } else if (index == 2) {
               if (navigationVoiceEnabled && mounted) {
                 await _flutterTts.speak("설정 페이지로 이동합니다.");
               }
-              await _setPortraitOrientation(); // Ensure portrait before navigating
+              await _setPortraitOrientation();
               Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (context) => const SettingsPage(),
-                ),
+                MaterialPageRoute(builder: (context) => const SettingsPage()),
               ).then((_) => _setPortraitOrientation());
             }
           },

--- a/app/lib/map/map_screen.dart
+++ b/app/lib/map/map_screen.dart
@@ -1,0 +1,59 @@
+// File: lib/map/map_screen.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+class MapScreen extends StatelessWidget {
+  final LatLng? currentLocation;
+  final MapController mapController;
+
+  const MapScreen({
+    super.key,
+    required this.currentLocation,
+    required this.mapController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FlutterMap(
+      mapController: mapController,
+      options: MapOptions(
+        initialCenter: currentLocation ?? LatLng(37.5665, 126.9780),
+        initialZoom: 15.0,
+        minZoom: 3.0,
+        maxZoom: 18.0,
+        maxBounds: LatLngBounds(
+          LatLng(-85.0, -180.0),
+          LatLng(85.0, 180.0),
+        ),
+      ),
+      children: [
+        TileLayer(
+          urlTemplate:
+              "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+          subdomains: const ['a', 'b', 'c'],
+          userAgentPackageName: 'com.oss.walk_guide',
+          tileProvider: NetworkTileProvider(),
+          tileSize: 256,
+          retinaMode: true,
+          backgroundColor: Colors.white,
+        ),
+        if (currentLocation != null)
+          MarkerLayer(
+            markers: [
+              Marker(
+                point: currentLocation!,
+                width: 50,
+                height: 50,
+                child: Image.asset(
+                  'assets/images/walkingIcon.png',
+                  width: 50,
+                  height: 50,
+                ),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -174,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -230,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.14.1"
   cross_file:
     dependency: transitive
     description:
@@ -741,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -997,6 +1021,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -1026,6 +1066,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.5"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -1082,6 +1138,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: "direct dev"
+    description:
+      name: test
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
@@ -1090,6 +1154,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.8"
   timing:
     dependency: transitive
     description:
@@ -1234,6 +1306,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   wkt_parser:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -53,6 +53,7 @@ dev_dependencies:
 
   build_runner: ^2.4.6
   hive_generator: ^2.0.1
+  test: ^1.25.15
 
 flutter:
   uses-material-design: true

--- a/app/test/map/map_screen_test.dart
+++ b/app/test/map/map_screen_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:walk_guide/map/map_screen.dart';
+import 'package:latlong2/latlong.dart';
+
+void main() {
+  testWidgets('MapScreen이 FlutterMap을 포함하고 있어야 함', (WidgetTester tester) async {
+    final mapController = MapController();
+    final currentLocation = LatLng(37.5665, 126.9780);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MapScreen(
+          currentLocation: currentLocation,
+          mapController: mapController,
+        ),
+      ),
+    );
+
+    // FlutterMap 위젯이 존재하는지 확인
+    expect(find.byType(FlutterMap), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# MapScreen 유닛 테스트 추가 및 커버리지 측정 기능 구현

##  주요 변경 사항
- `MapScreen`이 `FlutterMap`을 포함하는지 확인하는 widget test 추가
  - `test/map/map_screen_test.dart` 파일 생성
- 테스트 커버리지 측정을 위한 스크립트 `coverage_calc.py` 작성
  - 특정 파일(`lib/map/map_screen.dart`)의 라인 커버리지 확인 가능

## 개발 과정 요약
- `flutter test --coverage`로 테스트 커버리지 수집
- 대신 Python으로 커버리지 수치 계산

Closes #149 

